### PR TITLE
add in xcompat for game agnostic handling dry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 20

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sound_api_core"]
-	path = sound_api_core
-	url = https://github.com/mt-mods/sound_api_core.git

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,5 +4,5 @@ globals = {
 }
 
 read_globals = {
-    "default", "unifieddyes", "homedecor_roofing",
+    "default", "unifieddyes", "homedecor_roofing", "xcompat",
 }

--- a/README.md
+++ b/README.md
@@ -7,26 +7,17 @@ scrap into an iron lump.  Registered items: plate_hard, plate_soft,
 plate_rusted, grate_hard, grate_soft, strut, roofing.
 
 ## Install Guide
-This mod uses submodules(for the sounds library) so after cloning,
-move into the directory and do `git submodule init && git submodule update`
+clone the repo or install from contentdb
 
 ## Dependencies:
 
-This mod mod current has no hard dependecies.
+required depends
+* xcompat: allows this mod to be game agnostic
+
 there are a few optional ones to support sounds as well as others for additional content
 * homedecor_roofing: adds additional slopes for steel sheeting
 * default + unifieddyes: makes the default steel block dyable
 * streets: allows the mod to register a node in the streets mod if not present and keep compat both ways
-  
-## Supported Games:
-
-* Minetest Game - 100% - complete
-* Farlands Reloaded - 100% - complete
-* Mineclone2 - 100% - complete
-* Mineclone5 - 100% - complete
-* Mineclonia - 100% - complete
-* Exile - 10% - missing everything but sounds
-* Ksurvive - 10% - missing everything but sounds
 
 ## License:
 

--- a/crafts.lua
+++ b/crafts.lua
@@ -1,10 +1,4 @@
-local steel_item = "default:steel_ingot"
-
-if minetest.get_modpath("mcl_core") then
-	steel_item = "mcl_core:iron_ingot"
-elseif minetest.get_modpath("fl_ores") then
-	steel_item = "fl_ores:iron_ingot"
-end
+local steel_item = xcompat.materials.steel_ingot
 
 minetest.register_craft({
 	type = "cooking",

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,4 @@
 name = steel
 description = Adds a range of steel materials that are recyclable.
-optional_depends = default, streets, unifieddyes, homedecor_roofing, fl_stone, fl_trees, mcl_sounds
+depends = xcompat
+optional_depends = streets, unifieddyes, homedecor_roofing

--- a/nodes.lua
+++ b/nodes.lua
@@ -1,5 +1,4 @@
-local modpath = minetest.get_modpath("steel")
-local sound_api = dofile(modpath .. "/sound_api_core/init.lua")
+local sound_api = xcompat.sounds
 
 -- Item
 minetest.register_craftitem("steel:scrap", {


### PR DESCRIPTION
adds xcompat dep, a central place to handle game agnostic stuff for anyone, and so that we arent repeating ourselves (which we have to a degree) across existing mods. see previous discussions on the mt-mods communications channels